### PR TITLE
fix: miri problems when running test with flate2's zlib feature.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
 dependencies = [
  "crc32fast",
- "libz-sys",
  "miniz_oxide",
 ]
 
@@ -106,17 +105,6 @@ name = "libc"
 version = "0.2.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
-
-[[package]]
-name = "libz-sys"
-version = "1.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97137b25e321a73eef1418d1d5d2eda4d77e12813f8e6dead84bc52c5870a7b"
-dependencies = [
- "cc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "log"
@@ -204,12 +192,6 @@ name = "pin-project-lite"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "proc-macro2"
@@ -393,12 +375,6 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "winapi"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-flate2 = { version = "1.0.28", features = ["zlib"] }
+flate2 = "1"
 loom = { version = "0.7.1", optional = true }
 nom = "7.1.3"
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-flate2 = "1"
+flate2 = "1.0.28"
 loom = { version = "0.7.1", optional = true }
 nom = "7.1.3"
 


### PR DESCRIPTION
Fixes problems with PR #6.

This removes the `zlib` feature for flate2; now it gonna use the default `miniz_oxide` one.

I though that the `zlib` feature for the `flate2` crate enabled zlib decompressing, but instead it just dynamically links the "zlib-ng" C library if `extra maximum performance` is needed.

From flate2-rs README

> The default miniz_oxide backend has the advantage of being pure Rust. If you want maximum performance, you can use the [zlib] [feature]

Since, flate2 was dynamically linking this library, miri wasn't able to track the calls to this function.

Moving forward, if miri is finicky about this once again, you could slap a `#[cfg(not(miri))]` on the test function, which would skip that test from being run on miri. On this case, it was worthwhile to check the actual problem, because I wasn't aware how features were implemented on flate2.